### PR TITLE
Update README and add fork info modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
-Sounny's ColorBrewer
-==============
-This is built off of https://colorbrewer2.org/ and is a Web tool for guidance in choosing choropleth map color schemes, based on the research of [Dr. Cynthia Brewer](http://www.personal.psu.edu/cab38/). ColorBrezer2 is built and maintained by [Axis Maps](http://axismaps.com). This is Sounny's fork of ColorBrezer
+My ColorBrewer Fork
+===================
+
+This project is based on the original [ColorBrewer 2](https://colorbrewer2.org) project by Cynthia Brewer, Mark Harrower and Axis Maps at The Pennsylvania State University.
+
+It provides the same color scheme selection tools but is an independent fork and is not endorsed by the original authors. Use it as a starting point for customizing your own color palettes.

--- a/colorbrewer.js
+++ b/colorbrewer.js
@@ -412,7 +412,7 @@ function loadOverlays(o)
 		}
 	});
 }
-$(".learn-more, #how, #credits, #downloads").click(function(e){
+$(".learn-more, #how, #credits, #downloads, #fork-info").click(function(e){
 	e.stopPropagation();
 	var page;
 	switch( $(this).attr("id") ){
@@ -441,15 +441,20 @@ $(".learn-more, #how, #credits, #downloads").click(function(e){
 		page = "credits.html";
 		break;
 
-		case "downloads":
-		$("#learnmore-title").html("DOWNLOADS");
-		page = "downloads.html";
-		break;
+                case "downloads":
+                $("#learnmore-title").html("DOWNLOADS");
+                page = "downloads.html";
+                break;
 
-		case "context-learn-more":
-		$("#learnmore-title").html("MAP CONTEXT and BACKGROUND");
-		page = "context.html";
-		break;
+                case "fork-info":
+                $("#learnmore-title").html("ABOUT THIS FORK");
+                page = "fork-info.html";
+                break;
+
+                case "context-learn-more":
+                $("#learnmore-title").html("MAP CONTEXT and BACKGROUND");
+                page = "context.html";
+                break;
 	}
 	if ( page ){
 		$("#learnmore #content").load("learnmore/"+page,function(){

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
 			</div> <!--end left div-->
 			
 			<div id="header">
-				<p id="nav"><a id="how" href="#">how to use</a> | <a href="http://www.personal.psu.edu/cab38/ColorBrewer/ColorBrewer_updates.html" target="blank">updates</a> | <a id="downloads" href="#">downloads</a> | <a id="credits" href="#">credits</a></p>
+                                <p id="nav"><a id="how" href="#">how to use</a> | <a href="http://www.personal.psu.edu/cab38/ColorBrewer/ColorBrewer_updates.html" target="blank">updates</a> | <a id="downloads" href="#">downloads</a> | <a id="credits" href="#">credits</a> | <a id="fork-info" href="#">fork info</a></p>
 				<h1>COLOR<span>BREWER</span> 2.0</h1>
 				<h3>color advice for cartography</h3>
 			</div> <!--end header-->
@@ -163,13 +163,8 @@
 		
 		</div> <!--end wrapper div-->
 		
-		<div id="footer">
-			<a href="http://axismaps.com" target="_blank"><img src="images/axismaps.png" class="logo" alt="Axis Maps" title="Axis Maps"/></a>
-			<p>&copy; Cynthia Brewer, Mark Harrower and The Pennsylvania State University</p>
-			<p><a href="https://github.com/axismaps/colorbrewer/" target="_blank"><img src='images/GitHub-Mark-32px.png' class='gh'/>Source code and feedback</a></p>
-			<p><a href="http://colorbrewer.org/flash">Back to Flash version</a><br/>
-			<a href="http://www.personal.psu.edu/cab38/ColorBrewer/ColorBrewer.html">Back to ColorBrewer 1.0</a></p>
-		</div> <!--end footer-->
+                <div id="footer">
+                </div> <!--end footer-->
 		<div id="mask"></div>
 		<div id="learnmore" style="display:none">
 			<p id="close">X</p>

--- a/learnmore/fork-info.html
+++ b/learnmore/fork-info.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+<p>This project is a personal fork of <a href="https://colorbrewer2.org" target="_blank">ColorBrewer 2</a> originally created by Cynthia Brewer, Mark Harrower and Axis Maps at The Pennsylvania State University.</p>
+<p>The source code for the original version is available on <a href="https://github.com/axismaps/colorbrewer/" target="_blank">GitHub</a>. This fork is not affiliated with or endorsed by the original authors.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update README to explain that this is a fork of the original ColorBrewer project
- add a `fork info` button to the navigation bar
- remove legacy credits and Axis Maps logo from the footer
- include `fork-info.html` learn-more page with original project citation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f9938c1408327b6ed9c3a538cc207