### PR TITLE
Enhance Leaflet demo with color info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,5 @@
 - 2025-07-26 ChatGPT: Moved original site into version2 directory and added a new Leaflet-based demo with dynamic color schemes.
 - 2025-07-27 ChatGPT: Moved Leaflet demo into its own folder, added overview index page linking to version2 and the Leaflet demo, and updated README.
 - 2025-07-27 ChatGPT: Created `literature` directory, added placeholder README, updated root README, modernized `index.html` styling.
+
+- 2025-07-27 ChatGPT: Added hover tooltips showing RGB/HEX in Leaflet demo, legend with color chips, and probe UI.

--- a/leaflet/index.html
+++ b/leaflet/index.html
@@ -18,6 +18,8 @@
     </select>
   </label>
 </div>
+<div id="legend"></div>
+<div id="probe"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="../version2/colorbrewer_schemes.js"></script>
 <script src="main.js"></script>

--- a/leaflet/main.css
+++ b/leaflet/main.css
@@ -1,3 +1,6 @@
 html, body { margin: 0; padding: 0; height: 100%; }
 #map { width: 100%; height: 100%; }
 .controls { position: absolute; top: 10px; left: 10px; background: rgba(255,255,255,0.8); padding: 10px; z-index: 1000; font-family: sans-serif; }
+#legend { position: absolute; bottom: 10px; left: 10px; background: rgba(255,255,255,0.8); padding: 5px; z-index: 1000; display: flex; gap: 5px; font-family: sans-serif; }
+.legend-chip { width: 20px; height: 20px; border: 1px solid #ccc; cursor: pointer; }
+#probe { position: absolute; display: none; background: rgba(50,50,50,.85); color: #fff; font-size: 11px; font-weight: bold; line-height: 14px; padding: 4px; pointer-events: none; z-index: 1001; }

--- a/leaflet/main.js
+++ b/leaflet/main.js
@@ -6,6 +6,8 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 
 const schemeSelect = document.getElementById('scheme');
 const classesSelect = document.getElementById('classes');
+const legend = document.getElementById('legend');
+const probe = document.getElementById('probe');
 
 const seq = colorbrewer;
 const schemeNames = Object.keys(seq);
@@ -20,29 +22,96 @@ fetch('data/us-states.json')
   .then(resp => resp.json())
   .then(data => {
     let geo;
-    function styleFeature(feature) {
+    let breaks = [];
+    let colors = [];
+
+    function rgbArray(str){
+      return str.match(/\d+/g).map(Number);
+    }
+    function toHex(str){
+      const [r,g,b] = rgbArray(str);
+      return '#' + [r,g,b].map(x => x.toString(16).padStart(2,'0')).join('');
+    }
+
+    function computeBreaks(){
       const selected = schemeSelect.value || 'YlGn';
       const num = parseInt(classesSelect.value, 10) || 3;
+      colors = seq[selected][num];
       const values = data.features.map(f => f.properties.density);
       const sorted = values.slice().sort((a,b)=>a-b);
-      const breaks = [];
+      breaks = [];
       for(let i=1;i<num;i++) breaks.push(sorted[Math.floor(i*values.length/num)]);
-      function getColor(d){
-        const colors = seq[selected][num];
-        for(let i=num-1;i>0;i--){ if(d>=breaks[i-1]) return colors[i]; }
-        return colors[0];
-      }
+    }
+
+    function getClassIndex(d){
+      const num = parseInt(classesSelect.value, 10) || 3;
+      for(let i=num-1;i>0;i--){ if(d>=breaks[i-1]) return i; }
+      return 0;
+    }
+
+    function styleFeature(feature) {
+      const idx = getClassIndex(feature.properties.density);
       return {
         weight:1,
         color:'white',
-        fillColor: getColor(feature.properties.density),
+        fillColor: colors[idx],
         fillOpacity:0.7
       };
     }
 
+    function showProbeFromEvent(e, idx){
+      const color = colors[idx];
+      const [r,g,b] = rgbArray(color);
+      probe.innerHTML = `<p>${schemeSelect.value} class ${idx+1}<br/>HEX: ${toHex(color)}<br/>RGB: ${r}, ${g}, ${b}</p>`;
+      probe.style.left = (e.clientX + 10) + 'px';
+      probe.style.top = (e.clientY + 10) + 'px';
+      probe.style.display = 'block';
+    }
+
+    function onEachFeature(feature, layer){
+      const idx = getClassIndex(feature.properties.density);
+      layer.on({
+        mouseover(e){
+          layer.setStyle({weight:2});
+          showProbeFromEvent(e.originalEvent, idx);
+        },
+        mousemove(e){
+          showProbeFromEvent(e.originalEvent, idx);
+        },
+        mouseout(){
+          layer.setStyle({weight:1});
+          probe.style.display = 'none';
+        }
+      });
+    }
+
+    function updateLegend(){
+      legend.innerHTML = '';
+      colors.forEach(col => {
+        const chip = document.createElement('div');
+        chip.className = 'legend-chip';
+        chip.style.backgroundColor = col;
+        chip.addEventListener('mouseenter', e => {
+          const [r,g,b] = rgbArray(col);
+          probe.innerHTML = `<p>HEX: ${toHex(col)}<br/>RGB: ${r}, ${g}, ${b}</p>`;
+          probe.style.left = (e.clientX + 10) + 'px';
+          probe.style.top = (e.clientY + 10) + 'px';
+          probe.style.display = 'block';
+        });
+        chip.addEventListener('mousemove', e => {
+          probe.style.left = (e.clientX + 10) + 'px';
+          probe.style.top = (e.clientY + 10) + 'px';
+        });
+        chip.addEventListener('mouseleave', () => { probe.style.display = 'none'; });
+        legend.appendChild(chip);
+      });
+    }
+
     function redraw(){
+      computeBreaks();
       if(geo) geo.remove();
-      geo = L.geoJson(data, {style: styleFeature}).addTo(map);
+      geo = L.geoJson(data, {style: styleFeature, onEachFeature}).addTo(map);
+      updateLegend();
     }
 
     schemeSelect.addEventListener('change', redraw);


### PR DESCRIPTION
## Summary
- add legend and probe elements to the Leaflet demo
- style legend chips and tooltip
- show HEX/RGB values on hover over states or chips
- document changes in AGENTS log

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6885a079335c83279414b58e60e3f257