### PR TITLE
Center Leaflet map on southeast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,4 @@
 
 - 2025-07-28 ChatGPT: Consolidated repeated code in leaflet/main.js to prevent variable redeclaration; cleaned AGENTS.md merge markers.
 - 2025-07-28 ChatGPT: Added missing US counties GeoJSON dataset for Leaflet demo.
+- 2025-07-28 ChatGPT: Default Leaflet view focuses on southeastern US and loads counties layer on startup.

--- a/leaflet/index.html
+++ b/leaflet/index.html
@@ -20,7 +20,7 @@
   <label>Layer:
     <select id="layer">
       <option value="states">States</option>
-      <option value="counties">Counties</option>
+      <option value="counties" selected>Counties</option>
     </select>
   </label>
 </div>

--- a/leaflet/main.js
+++ b/leaflet/main.js
@@ -1,5 +1,6 @@
 // Initialize Leaflet map
-const map = L.map('map').setView([37.8, -96], 4);
+// Start focused on the southeastern US like the original ColorBrewer map
+const map = L.map('map').setView([31, -85], 6);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   maxZoom: 18,
   attribution: '&copy; OpenStreetMap contributors'


### PR DESCRIPTION
## Summary
- start Leaflet map focused on the southeastern U.S.
- default to the counties layer in the Leaflet demo
- log these changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68878a9f93b0832787675e71c53fa4ae