### PR TITLE
feat: show CMYK values in legend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,4 @@
 - 2025-07-28 ChatGPT: Added missing US counties GeoJSON dataset for Leaflet demo.
 - 2025-07-28 ChatGPT: Default Leaflet view focuses on southeastern US and loads counties layer on startup.
 - 2025-07-29 ChatGPT: Grouped palettes by type with descriptions and range labels to guide scheme selection in Leaflet demo.
+- 2025-08-19 ChatGPT: Legend probe now displays HEX, RGB, and CMYK values for each color.

--- a/leaflet/main.js
+++ b/leaflet/main.js
@@ -60,6 +60,15 @@ function toHex(str) {
   return '#' + [r, g, b].map(x => x.toString(16).padStart(2, '0')).join('');
 }
 
+function toCmyk(str) {
+  const [r, g, b] = rgbArray(str).map(v => v / 255);
+  const k = 1 - Math.max(r, g, b);
+  const c = (1 - r - k) / (1 - k) || 0;
+  const m = (1 - g - k) / (1 - k) || 0;
+  const y = (1 - b - k) / (1 - k) || 0;
+  return [c, m, y, k].map(x => Math.round(x * 100));
+}
+
 function computeBreaks() {
   const scheme = schemeSelect.value || 'YlGn';
   const num = parseInt(classesSelect.value, 10) || 3;
@@ -96,7 +105,8 @@ function styleFeature(feature) {
 function showProbeFromEvent(e, idx) {
   const col = colors[idx];
   const [r, g, b] = rgbArray(col);
-  probe.innerHTML = `<p>${schemeSelect.value} class ${idx + 1}<br/>HEX: ${toHex(col)}<br/>RGB: ${r}, ${g}, ${b}</p>`;
+  const [c, m, y, k] = toCmyk(col);
+  probe.innerHTML = `<p>${schemeSelect.value} class ${idx + 1}<br/>HEX: ${toHex(col)}<br/>RGB: ${r}, ${g}, ${b}<br/>CMYK: ${c}, ${m}, ${y}, ${k}</p>`;
   probe.style.left = (e.clientX + 10) + 'px';
   probe.style.top = (e.clientY + 10) + 'px';
   probe.style.display = 'block';
@@ -126,11 +136,13 @@ function updateLegend() {
     item.className = 'legend-item';
     const chip = document.createElement('span');
     const col = colors[idx];
+    const [r, g, b] = rgbArray(col);
+    const [c, m, y, k] = toCmyk(col);
     chip.className = 'legend-chip';
     chip.style.backgroundColor = col;
+    chip.title = `HEX: ${toHex(col)} RGB: ${r}, ${g}, ${b} CMYK: ${c}, ${m}, ${y}, ${k}`;
     chip.addEventListener('mouseenter', e => {
-      const [r, g, b] = rgbArray(col);
-      probe.innerHTML = `<p>HEX: ${toHex(col)}<br/>RGB: ${r}, ${g}, ${b}</p>`;
+      probe.innerHTML = `<p>HEX: ${toHex(col)}<br/>RGB: ${r}, ${g}, ${b}<br/>CMYK: ${c}, ${m}, ${y}, ${k}</p>`;
       probe.style.left = (e.clientX + 10) + 'px';
       probe.style.top = (e.clientY + 10) + 'px';
       probe.style.display = 'block';


### PR DESCRIPTION
## Summary
- expose HEX, RGB, and CMYK values in Leaflet legend and probe
- log addition of color value display

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/colorbrewer/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a4fb6cafc88327b70b0800a94ffef9