### PR TITLE
Add palette export options to Leaflet demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,4 @@
 - 2025-07-28 ChatGPT: Default Leaflet view focuses on southeastern US and loads counties layer on startup.
 - 2025-07-29 ChatGPT: Grouped palettes by type with descriptions and range labels to guide scheme selection in Leaflet demo.
 - 2025-08-19 ChatGPT: Legend probe now displays HEX, RGB, and CMYK values for each color.
+- 2025-08-19 ChatGPT: Added export panel to Leaflet demo allowing palette downloads as ASE/GPL/CLR and JS/CSS snippets.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 This repository holds two ways to explore the ColorBrewer palettes. The
 `version2/` directory preserves the classic ColorBrewer 2 web interface, while
 `leaflet/` contains a lightweight Leaflet example that lets you apply the color
-schemes to a simple map. The `literature/` folder collects reference material
-used while developing the site.
+schemes to a simple map and export the active palette as Adobe Swatch Exchange,
+GIMP palette, Esri colormap, or copyable CSS/JavaScript snippets. The
+`literature/` folder collects reference material used while developing the site.
 
 Open `index.html` at the project root for background information and links to
 each version.

--- a/leaflet/index.html
+++ b/leaflet/index.html
@@ -27,6 +27,17 @@
 </div>
 <div id="legend"></div>
 <div id="probe"></div>
+<div id="export">
+  <div><strong>Export:</strong></div>
+  <div class="export-links">
+    <a id="export-ase" download>ASE</a>
+    <a id="export-gpl" download>GPL</a>
+    <a id="export-clr" download>CLR</a>
+    <button id="copy-js" type="button">JS</button>
+    <button id="copy-css" type="button">CSS</button>
+  </div>
+  <textarea id="export-text" readonly></textarea>
+</div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="../version2/colorbrewer_schemes.js"></script>
 <script src="main.js"></script>

--- a/leaflet/main.css
+++ b/leaflet/main.css
@@ -6,3 +6,7 @@ html, body { margin: 0; padding: 0; height: 100%; }
 .legend-item { display: flex; align-items: center; gap: 4px; }
 .legend-chip { width: 20px; height: 20px; border: 1px solid #ccc; cursor: pointer; flex: none; }
 #probe { position: absolute; display: none; background: rgba(50,50,50,.85); color: #fff; font-size: 11px; font-weight: bold; line-height: 14px; padding: 4px; pointer-events: none; z-index: 1001; }
+#export { position: absolute; bottom: 10px; right: 10px; background: rgba(255,255,255,0.8); padding: 5px; z-index: 1000; font-family: sans-serif; width: 180px; }
+#export .export-links { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
+#export a, #export button { background: #eee; border: 1px solid #ccc; padding: 2px 4px; font-size: 12px; text-decoration: none; cursor: pointer; }
+#export textarea { width: 100%; height: 60px; margin-top: 4px; font-size: 11px; }

--- a/leaflet/main.js
+++ b/leaflet/main.js
@@ -13,6 +13,12 @@ const layerSelect = document.getElementById('layer');
 const legend = document.getElementById('legend');
 const probe = document.getElementById('probe');
 const schemeInfo = document.getElementById('scheme-info');
+const exportAse = document.getElementById('export-ase');
+const exportGpl = document.getElementById('export-gpl');
+const exportClr = document.getElementById('export-clr');
+const exportText = document.getElementById('export-text');
+const copyJsBtn = document.getElementById('copy-js');
+const copyCssBtn = document.getElementById('copy-css');
 
 // Shared data and style state
 let data, geo;
@@ -160,12 +166,45 @@ function updateLegend() {
   });
 }
 
+function updateExports() {
+  const scheme = schemeSelect.value;
+  const num = parseInt(classesSelect.value, 10);
+  exportAse.href = `../version2/export/ase/${scheme}_${num}.ase`;
+  exportAse.download = `${scheme}_${num}.ase`;
+  exportGpl.href = `../version2/export/gpl/${scheme}_${num}.gpl`;
+  exportGpl.download = `${scheme}_${num}.gpl`;
+  const lines = colors.map((hx, i) => {
+    const rgb = hx.match(/\w\w/g).map(h => parseInt(h, 16));
+    return `${i + 1} ${rgb[0]} ${rgb[1]} ${rgb[2]}`;
+  }).join('\n');
+  const blob = new Blob([lines], { type: 'text/plain' });
+  if (exportClr.href && exportClr.href.startsWith('blob:')) {
+    URL.revokeObjectURL(exportClr.href);
+  }
+  exportClr.href = URL.createObjectURL(blob);
+  exportClr.download = `${scheme}_${num}.clr`;
+}
+
+copyJsBtn.addEventListener('click', () => {
+  const text = JSON.stringify(colors);
+  exportText.value = text;
+  navigator.clipboard.writeText(text);
+});
+
+copyCssBtn.addEventListener('click', () => {
+  const lines = colors.map((c, i) => `--color-${i + 1}: ${c};`);
+  const text = ':root {\n  ' + lines.join('\n  ') + '\n}';
+  exportText.value = text;
+  navigator.clipboard.writeText(text);
+});
+
 function redraw() {
   computeBreaks();
   updateSchemeInfo();
   if (geo) geo.remove();
   geo = L.geoJson(data, { style: styleFeature, onEachFeature }).addTo(map);
   updateLegend();
+  updateExports();
 }
 
 function loadData() {


### PR DESCRIPTION
## Summary
- add export panel to Leaflet demo for palette downloads (ASE, GPL, CLR)
- allow copying palette as CSS variables or JavaScript array
- document export options in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a50f63025483278abcd071b002cc80