### PR TITLE
Fix CLR export file format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,4 @@
 - 2025-07-29 ChatGPT: Grouped palettes by type with descriptions and range labels to guide scheme selection in Leaflet demo.
 - 2025-08-19 ChatGPT: Legend probe now displays HEX, RGB, and CMYK values for each color.
 - 2025-08-19 ChatGPT: Added export panel to Leaflet demo allowing palette downloads as ASE/GPL/CLR and JS/CSS snippets.
+- 2025-08-20 ChatGPT: Fixed CLR export to include alpha channel and 0-based indices for better compatibility.

--- a/leaflet/main.js
+++ b/leaflet/main.js
@@ -173,10 +173,12 @@ function updateExports() {
   exportAse.download = `${scheme}_${num}.ase`;
   exportGpl.href = `../version2/export/gpl/${scheme}_${num}.gpl`;
   exportGpl.download = `${scheme}_${num}.gpl`;
-  const lines = colors.map((hx, i) => {
-    const rgb = hx.match(/\w\w/g).map(h => parseInt(h, 16));
-    return `${i + 1} ${rgb[0]} ${rgb[1]} ${rgb[2]}`;
-  }).join('\n');
+  const lines = colors
+    .map((hx, i) => {
+      const rgb = hx.match(/\w\w/g).map(h => parseInt(h, 16));
+      return `${i} ${rgb[0]} ${rgb[1]} ${rgb[2]} 255`;
+    })
+    .join('\n') + '\n';
   const blob = new Blob([lines], { type: 'text/plain' });
   if (exportClr.href && exportClr.href.startsWith('blob:')) {
     URL.revokeObjectURL(exportClr.href);


### PR DESCRIPTION
## Summary
- ensure CLR palette export uses 0-based indices and adds an alpha column for compatibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cde5b8fc83279a7d7f3623a8a571