### PR TITLE
Enhance Leaflet demo with ColorBrewer-style controls and guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,5 @@
 - 2025-08-21 ChatGPT: Refreshed version2 UI with card-based control panel, modern export panel, and updated styles for clearer hierarchy.
 - 2025-11-20 ChatGPT: Added Leaflet improvement ideas document and linked it from the root README while keeping the existing demo untouched.
 - 2025-11-21 ChatGPT: Reverted version2 interface to the original Cynthia Brewer Version 2 look; keep future changes true to that design.
+
+- 2026-03-14 GPT-5.2-Codex: Enhanced Leaflet demo to better reflect ColorBrewer spirit with guidance-first control panel, quantile/equal interval classification toggle, palette reversal, clearer legend, and richer map hover context.

--- a/leaflet/index.html
+++ b/leaflet/index.html
@@ -9,6 +9,8 @@
 <body>
 <div id="map"></div>
 <div class="controls">
+  <h1>ColorBrewer for Leaflet</h1>
+  <p class="tagline">Choose smart color schemes for your map data.</p>
   <label>Scheme:
     <select id="scheme"></select>
   </label>
@@ -17,6 +19,15 @@
       <option>3</option><option>4</option><option>5</option><option>6</option><option>7</option>
     </select>
   </label>
+  <label>Classification:
+    <select id="mode">
+      <option value="quantile" selected>Quantile</option>
+      <option value="equal">Equal interval</option>
+    </select>
+  </label>
+  <label class="inline-toggle">
+    <input type="checkbox" id="reverse" /> Reverse palette
+  </label>
   <label>Layer:
     <select id="layer">
       <option value="states">States</option>
@@ -24,6 +35,7 @@
     </select>
   </label>
   <div id="scheme-info"></div>
+  <div id="recommendation"></div>
 </div>
 <div id="legend"></div>
 <div id="probe"></div>

--- a/leaflet/main.css
+++ b/leaflet/main.css
@@ -1,12 +1,155 @@
-html, body { margin: 0; padding: 0; height: 100%; }
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
 #map { width: 100%; height: 100%; }
-.controls { position: absolute; top: 10px; right: 10px; background: rgba(255,255,255,0.8); padding: 10px; z-index: 1000; font-family: sans-serif; }
-#scheme-info { margin-top: 5px; font-size: 12px; max-width: 150px; }
-#legend { position: absolute; bottom: 10px; left: 10px; background: rgba(255,255,255,0.8); padding: 5px; z-index: 1000; display: flex; flex-direction: column; gap: 4px; font-family: sans-serif; }
-.legend-item { display: flex; align-items: center; gap: 4px; }
-.legend-chip { width: 20px; height: 20px; border: 1px solid #ccc; cursor: pointer; flex: none; }
-#probe { position: absolute; display: none; background: rgba(50,50,50,.85); color: #fff; font-size: 11px; font-weight: bold; line-height: 14px; padding: 4px; pointer-events: none; z-index: 1001; }
-#export { position: absolute; bottom: 10px; right: 10px; background: rgba(255,255,255,0.8); padding: 5px; z-index: 1000; font-family: sans-serif; width: 180px; }
-#export .export-links { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
-#export a, #export button { background: #eee; border: 1px solid #ccc; padding: 2px 4px; font-size: 12px; text-decoration: none; cursor: pointer; }
-#export textarea { width: 100%; height: 60px; margin-top: 4px; font-size: 11px; }
+
+.controls {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 280px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid #7f7f7f;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+  padding: 10px;
+  z-index: 1000;
+}
+
+.controls h1 {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.tagline {
+  margin: 4px 0 10px;
+  font-size: 12px;
+  color: #4b4b4b;
+}
+
+.controls label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.controls select {
+  display: block;
+  width: 100%;
+  margin-top: 3px;
+  border: 1px solid #888;
+  padding: 2px;
+  font-size: 12px;
+  background: #fff;
+}
+
+.inline-toggle {
+  display: flex !important;
+  align-items: center;
+  gap: 6px;
+  font-weight: normal !important;
+}
+
+#scheme-info,
+#recommendation {
+  font-size: 12px;
+  padding: 6px;
+  border: 1px solid #d9d9d9;
+  background: #f6f6f6;
+}
+
+#scheme-info { margin-top: 6px; }
+#recommendation { margin-top: 6px; }
+
+#legend {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  min-width: 190px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid #7f7f7f;
+  padding: 8px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.legend-title {
+  font-size: 12px;
+  font-weight: bold;
+  margin-bottom: 3px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.legend-chip {
+  width: 22px;
+  height: 16px;
+  border: 1px solid #b9b9b9;
+  cursor: pointer;
+  flex: none;
+}
+
+#probe {
+  position: absolute;
+  display: none;
+  background: rgba(35, 35, 35, 0.92);
+  color: #fff;
+  font-size: 11px;
+  line-height: 14px;
+  padding: 5px 6px;
+  border-radius: 2px;
+  pointer-events: none;
+  z-index: 1001;
+}
+
+#probe p { margin: 0; }
+
+#export {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  width: 230px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid #7f7f7f;
+  padding: 8px;
+  z-index: 1000;
+  font-size: 12px;
+}
+
+#export .export-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+#export a,
+#export button {
+  background: #efefef;
+  border: 1px solid #9d9d9d;
+  padding: 2px 6px;
+  font-size: 12px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+#export textarea {
+  width: 100%;
+  height: 64px;
+  margin-top: 6px;
+  border: 1px solid #bbb;
+  font-size: 11px;
+  resize: vertical;
+}

--- a/leaflet/main.js
+++ b/leaflet/main.js
@@ -9,10 +9,13 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 // Controls
 const schemeSelect = document.getElementById('scheme');
 const classesSelect = document.getElementById('classes');
+const modeSelect = document.getElementById('mode');
+const reverseCheck = document.getElementById('reverse');
 const layerSelect = document.getElementById('layer');
 const legend = document.getElementById('legend');
 const probe = document.getElementById('probe');
 const schemeInfo = document.getElementById('scheme-info');
+const recommendation = document.getElementById('recommendation');
 const exportAse = document.getElementById('export-ase');
 const exportGpl = document.getElementById('export-gpl');
 const exportClr = document.getElementById('export-clr');
@@ -21,9 +24,13 @@ const copyJsBtn = document.getElementById('copy-js');
 const copyCssBtn = document.getElementById('copy-css');
 
 // Shared data and style state
-let data, geo;
-let breaks = [], colors = [], ranges = [];
-let minVal = 0, maxVal = 0;
+let data;
+let geo;
+let breaks = [];
+let colors = [];
+let ranges = [];
+let minVal = 0;
+let maxVal = 0;
 
 // Populate color scheme options
 const seq = colorbrewer;
@@ -32,11 +39,12 @@ Object.entries(seq).forEach(([name, val]) => {
   const t = val.properties?.type;
   if (schemesByType[t]) schemesByType[t].push(name);
 });
+
 const typeLabels = { seq: 'Sequential', div: 'Diverging', qual: 'Qualitative' };
-Object.keys(typeLabels).forEach(t => {
+Object.keys(typeLabels).forEach((t) => {
   const group = document.createElement('optgroup');
   group.label = typeLabels[t];
-  schemesByType[t].sort().forEach(name => {
+  schemesByType[t].sort().forEach((name) => {
     const opt = document.createElement('option');
     opt.value = name;
     opt.textContent = name;
@@ -46,14 +54,21 @@ Object.keys(typeLabels).forEach(t => {
 });
 
 const typeDescriptions = {
-  seq: 'Sequential schemes work for ordered data from low to high.',
-  div: 'Diverging schemes emphasize deviation around a midpoint.',
-  qual: 'Qualitative schemes highlight categorical differences.'
+  seq: 'Sequential: ordered low→high values (light to dark).',
+  div: 'Diverging: data around a meaningful middle value.',
+  qual: 'Qualitative: categorical classes with no order.'
+};
+
+const recommendationByType = {
+  seq: 'Tip: use sequential when values have a natural order and no critical midpoint.',
+  div: 'Tip: use diverging when low/high sides must be balanced around a key value.',
+  qual: 'Tip: use qualitative for categories, not magnitude.'
 };
 
 function updateSchemeInfo() {
   const t = seq[schemeSelect.value]?.properties?.type;
   schemeInfo.textContent = t ? typeDescriptions[t] : '';
+  recommendation.textContent = t ? recommendationByType[t] : '';
 }
 
 // Utility helpers
@@ -63,32 +78,52 @@ function rgbArray(str) {
 
 function toHex(str) {
   const [r, g, b] = rgbArray(str);
-  return '#' + [r, g, b].map(x => x.toString(16).padStart(2, '0')).join('');
+  return `#${[r, g, b].map((x) => x.toString(16).padStart(2, '0')).join('')}`;
 }
 
 function toCmyk(str) {
-  const [r, g, b] = rgbArray(str).map(v => v / 255);
+  const [r, g, b] = rgbArray(str).map((v) => v / 255);
   const k = 1 - Math.max(r, g, b);
   const c = (1 - r - k) / (1 - k) || 0;
   const m = (1 - g - k) / (1 - k) || 0;
   const y = (1 - b - k) / (1 - k) || 0;
-  return [c, m, y, k].map(x => Math.round(x * 100));
+  return [c, m, y, k].map((x) => Math.round(x * 100));
+}
+
+function computeQuantileBreaks(values, num) {
+  const sorted = values.slice().sort((a, b) => a - b);
+  const quantileBreaks = [];
+  for (let i = 1; i < num; i += 1) {
+    quantileBreaks.push(sorted[Math.floor((i * sorted.length) / num)]);
+  }
+  return quantileBreaks;
+}
+
+function computeEqualBreaks(num) {
+  const step = (maxVal - minVal) / num;
+  const equalBreaks = [];
+  for (let i = 1; i < num; i += 1) {
+    equalBreaks.push(minVal + i * step);
+  }
+  return equalBreaks;
 }
 
 function computeBreaks() {
   const scheme = schemeSelect.value || 'YlGn';
   const num = parseInt(classesSelect.value, 10) || 3;
-  colors = seq[scheme][num];
-  const values = data.features.map(f => f.properties.density);
+  const schemeColors = seq[scheme][num];
+  colors = reverseCheck.checked ? schemeColors.slice().reverse() : schemeColors.slice();
+
+  const values = data.features.map((f) => f.properties.density);
   minVal = Math.min(...values);
   maxVal = Math.max(...values);
-  const sorted = values.slice().sort((a, b) => a - b);
-  breaks = [];
-  for (let i = 1; i < num; i++) {
-    breaks.push(sorted[Math.floor(i * values.length / num)]);
-  }
+
+  breaks = modeSelect.value === 'equal'
+    ? computeEqualBreaks(num)
+    : computeQuantileBreaks(values, num);
+
   ranges = [];
-  for (let i = 0; i < num; i++) {
+  for (let i = 0; i < num; i += 1) {
     const from = i === 0 ? minVal : breaks[i - 1];
     const to = i === num - 1 ? maxVal : breaks[i];
     ranges.push([from, to]);
@@ -97,7 +132,7 @@ function computeBreaks() {
 
 function getClassIndex(d) {
   const num = parseInt(classesSelect.value, 10) || 3;
-  for (let i = num - 1; i > 0; i--) {
+  for (let i = num - 1; i > 0; i -= 1) {
     if (d >= breaks[i - 1]) return i;
   }
   return 0;
@@ -105,41 +140,59 @@ function getClassIndex(d) {
 
 function styleFeature(feature) {
   const idx = getClassIndex(feature.properties.density);
-  return { weight: 1, color: 'white', fillColor: colors[idx], fillOpacity: 0.7 };
+  return {
+    weight: 0.8,
+    color: '#fff',
+    fillColor: colors[idx],
+    fillOpacity: 0.78
+  };
 }
 
-function showProbeFromEvent(e, idx) {
+function showProbeFromEvent(e, idx, labelPrefix = '') {
   const col = colors[idx];
   const [r, g, b] = rgbArray(col);
   const [c, m, y, k] = toCmyk(col);
-  probe.innerHTML = `<p>${schemeSelect.value} class ${idx + 1}<br/>HEX: ${toHex(col)}<br/>RGB: ${r}, ${g}, ${b}<br/>CMYK: ${c}, ${m}, ${y}, ${k}</p>`;
-  probe.style.left = (e.clientX + 10) + 'px';
-  probe.style.top = (e.clientY + 10) + 'px';
+  const title = labelPrefix || `${schemeSelect.value} class ${idx + 1}`;
+  probe.innerHTML = `<p>${title}<br>HEX: ${toHex(col)}<br>RGB: ${r}, ${g}, ${b}<br>CMYK: ${c}, ${m}, ${y}, ${k}</p>`;
+  probe.style.left = `${e.clientX + 10}px`;
+  probe.style.top = `${e.clientY + 10}px`;
   probe.style.display = 'block';
 }
 
 function onEachFeature(feature, layer) {
-  const idx = getClassIndex(feature.properties.density);
   layer.on({
     mouseover(e) {
-      layer.setStyle({ weight: 2 });
-      showProbeFromEvent(e.originalEvent, idx);
+      const idx = getClassIndex(feature.properties.density);
+      layer.setStyle({ weight: 1.5, color: '#333' });
+      showProbeFromEvent(e.originalEvent, idx, `${feature.properties.name || 'Area'}: ${feature.properties.density.toFixed(1)}`);
     },
     mousemove(e) {
-      showProbeFromEvent(e.originalEvent, idx);
+      const idx = getClassIndex(feature.properties.density);
+      showProbeFromEvent(e.originalEvent, idx, `${feature.properties.name || 'Area'}: ${feature.properties.density.toFixed(1)}`);
     },
     mouseout() {
-      layer.setStyle({ weight: 1 });
+      geo.resetStyle(layer);
       probe.style.display = 'none';
     }
   });
 }
 
+function formatRangeLabel(range) {
+  return `${range[0].toFixed(1)} – ${range[1].toFixed(1)}`;
+}
+
 function updateLegend() {
   legend.innerHTML = '';
+
+  const title = document.createElement('div');
+  title.className = 'legend-title';
+  title.textContent = `Legend (${modeSelect.value === 'equal' ? 'Equal interval' : 'Quantile'})`;
+  legend.appendChild(title);
+
   ranges.forEach((range, idx) => {
     const item = document.createElement('div');
     item.className = 'legend-item';
+
     const chip = document.createElement('span');
     const col = colors[idx];
     const [r, g, b] = rgbArray(col);
@@ -147,21 +200,23 @@ function updateLegend() {
     chip.className = 'legend-chip';
     chip.style.backgroundColor = col;
     chip.title = `HEX: ${toHex(col)} RGB: ${r}, ${g}, ${b} CMYK: ${c}, ${m}, ${y}, ${k}`;
-    chip.addEventListener('mouseenter', e => {
-      probe.innerHTML = `<p>HEX: ${toHex(col)}<br/>RGB: ${r}, ${g}, ${b}<br/>CMYK: ${c}, ${m}, ${y}, ${k}</p>`;
-      probe.style.left = (e.clientX + 10) + 'px';
-      probe.style.top = (e.clientY + 10) + 'px';
-      probe.style.display = 'block';
+    chip.addEventListener('mouseenter', (e) => {
+      showProbeFromEvent(e, idx, `${schemeSelect.value} class ${idx + 1}`);
     });
-    chip.addEventListener('mousemove', e => {
-      probe.style.left = (e.clientX + 10) + 'px';
-      probe.style.top = (e.clientY + 10) + 'px';
+    chip.addEventListener('mousemove', (e) => {
+      probe.style.left = `${e.clientX + 10}px`;
+      probe.style.top = `${e.clientY + 10}px`;
     });
-    chip.addEventListener('mouseleave', () => { probe.style.display = 'none'; });
+    chip.addEventListener('mouseleave', () => {
+      probe.style.display = 'none';
+    });
+
     item.appendChild(chip);
+
     const label = document.createElement('span');
-    label.textContent = `${range[0].toFixed(1)} – ${range[1].toFixed(1)}`;
+    label.textContent = formatRangeLabel(range);
     item.appendChild(label);
+
     legend.appendChild(item);
   });
 }
@@ -173,12 +228,14 @@ function updateExports() {
   exportAse.download = `${scheme}_${num}.ase`;
   exportGpl.href = `../version2/export/gpl/${scheme}_${num}.gpl`;
   exportGpl.download = `${scheme}_${num}.gpl`;
+
   const lines = colors
-    .map((hx, i) => {
-      const rgb = hx.match(/\w\w/g).map(h => parseInt(h, 16));
+    .map((rgbString, i) => {
+      const rgb = rgbArray(rgbString);
       return `${i} ${rgb[0]} ${rgb[1]} ${rgb[2]} 255`;
     })
     .join('\n') + '\n';
+
   const blob = new Blob([lines], { type: 'text/plain' });
   if (exportClr.href && exportClr.href.startsWith('blob:')) {
     URL.revokeObjectURL(exportClr.href);
@@ -188,23 +245,26 @@ function updateExports() {
 }
 
 copyJsBtn.addEventListener('click', () => {
-  const text = JSON.stringify(colors);
+  const text = JSON.stringify(colors.map(toHex));
   exportText.value = text;
   navigator.clipboard.writeText(text);
 });
 
 copyCssBtn.addEventListener('click', () => {
-  const lines = colors.map((c, i) => `--color-${i + 1}: ${c};`);
-  const text = ':root {\n  ' + lines.join('\n  ') + '\n}';
+  const lines = colors.map((c, i) => `--color-${i + 1}: ${toHex(c)};`);
+  const text = `:root {\n  ${lines.join('\n  ')}\n}`;
   exportText.value = text;
   navigator.clipboard.writeText(text);
 });
 
 function redraw() {
+  if (!data) return;
   computeBreaks();
   updateSchemeInfo();
+
   if (geo) geo.remove();
   geo = L.geoJson(data, { style: styleFeature, onEachFeature }).addTo(map);
+
   updateLegend();
   updateExports();
 }
@@ -212,19 +272,24 @@ function redraw() {
 function loadData() {
   const url = layerSelect.value === 'counties' ? 'data/us-counties.json' : 'data/us-states.json';
   fetch(url)
-    .then(resp => {
-      if (!resp.ok) throw new Error('GeoJSON not found: ' + url);
+    .then((resp) => {
+      if (!resp.ok) throw new Error(`GeoJSON not found: ${url}`);
       return resp.json();
     })
-    .then(json => { data = json; redraw(); })
-    .catch(err => {
+    .then((json) => {
+      data = json;
+      redraw();
+    })
+    .catch((err) => {
       console.error(err);
-      alert('Could not load ' + url + '. Please add the file to the data folder.');
+      alert(`Could not load ${url}. Please add the file to the data folder.`);
     });
 }
 
 schemeSelect.addEventListener('change', redraw);
 classesSelect.addEventListener('change', redraw);
+modeSelect.addEventListener('change', redraw);
+reverseCheck.addEventListener('change', redraw);
 layerSelect.addEventListener('change', loadData);
 
 // Initial load


### PR DESCRIPTION
### Motivation
- Make the Leaflet demo feel and behave more like the original ColorBrewer tool by prioritizing guidance and common cartographic workflows. 
- Provide simple controls for classification method and palette direction so map authors can try common styling patterns quickly.

### Description
- Updated `leaflet/index.html` to add a guidance-first control panel (title/tagline), a `mode` select for classification (`quantile` / `equal`), a `reverse` palette checkbox, and a `recommendation` area for scheme-type tips. 
- Reworked `leaflet/main.css` to style the panel, legend, probe and export panels with a compact, card-like presentation that improves readability. 
- Rewrote `leaflet/main.js` to wire the new controls into rendering: added `modeSelect` and `reverseCheck`, compute both quantile and equal-interval breaks, apply palette reversal, improve hover/probe text to include area name and numeric value plus HEX/RGB/CMYK, and render a clearer legend with explicit mode labeling. 
- Updated export/copy behavior so the JS/CSS copy actions emit HEX values for easier reuse, and appended a short change log entry to `AGENTS.md`.

### Testing
- Ran `node --check leaflet/main.js` which completed successfully. 
- Ran `npm test` which failed as expected because the repository has no `package.json` / test script (failure is environmental, not code-related).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b58adda0908327ab19ece1c598ee5f)